### PR TITLE
Use lodash to help de-dup a consumer's build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,7 @@
     "url": "https://github.com/yola/drf-paginator/issues"
   },
   "dependencies": {
-    "lodash.assign": "~4.1.0",
-    "lodash.clonedeep": "~4.4.1",
-    "lodash.omit": "~4.4.1",
-    "lodash.reduce": "~4.5.1"
+    "lodash": "4.x"
   },
   "devDependencies": {
     "babel-cli": "~6.11.4",

--- a/src/helpers/request-spy.js
+++ b/src/helpers/request-spy.js
@@ -1,4 +1,4 @@
-import assign from 'lodash.assign';
+import _ from 'lodash';
 import sinon from 'sinon';
 
 import pageNumberResponse from '../fixtures/page-number-response.json';
@@ -6,7 +6,7 @@ import pageNumberResponse from '../fixtures/page-number-response.json';
 
 export const request = function(options, queryParams) {
   const uniqueValue = Math.random();
-  const response = assign({}, pageNumberResponse, { uniqueValue });
+  const response = _.assign({}, pageNumberResponse, { uniqueValue });
 
   return Promise.resolve(response);
 };

--- a/src/page-merger.js
+++ b/src/page-merger.js
@@ -1,5 +1,4 @@
-import reduce from 'lodash.reduce';
-
+import _ from 'lodash';
 
 class PageMerger {
   constructor(paginator) {
@@ -39,7 +38,7 @@ class PageMerger {
       results: []
     };
 
-    return reduce(responses, merge, defaultResult);
+    return _.reduce(responses, merge, defaultResult);
   }
 }
 

--- a/src/paginators/base-paginator.js
+++ b/src/paginators/base-paginator.js
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash.clonedeep';
+import _ from 'lodash';
 
 import * as actions from '../actions';
 import PaginatorError from '../paginator-error';
@@ -13,7 +13,7 @@ export class BasePaginator {
     this._cache = Object.create(null);
     this._page = 0;
     this._request = request;
-    this._requestOptions = cloneDeep(requestOptions);
+    this._requestOptions = _.cloneDeep(requestOptions);
     this.queryHandler = null;
   }
 
@@ -49,7 +49,7 @@ export class BasePaginator {
   fetchPage(page) {
     if (this._hasRequest(page)) {
       return this._getRequest(page)
-        .then(cloneDeep);
+        .then(_.cloneDeep);
     }
 
     if (!this._isValidPage(page)) {
@@ -65,7 +65,7 @@ export class BasePaginator {
 
     this._cacheRequest(page, request);
 
-    return request.then(cloneDeep);
+    return request.then(_.cloneDeep);
   }
 
   fetchPageCount() {
@@ -114,7 +114,7 @@ export class BasePaginator {
       throw new PaginatorError(errors.queryHandlerMissing);
     }
 
-    const requestOptions = cloneDeep(this._requestOptions);
+    const requestOptions = _.cloneDeep(this._requestOptions);
     const queryParams = this.queryHandler.makeParams(page);
 
     return this._request(requestOptions, queryParams);

--- a/src/query-handlers/limit-offset-query-handler.js
+++ b/src/query-handlers/limit-offset-query-handler.js
@@ -1,5 +1,4 @@
-import assign from 'lodash.assign';
-import omit from 'lodash.omit';
+import _ from 'lodash';
 
 import * as actions from '../actions';
 import PaginatorError from '../paginator-error';
@@ -24,7 +23,7 @@ export class LimitOffsetQueryHandler {
 
   makeParams(page) {
     const opts = this._options;
-    const queryParams = assign({}, this._excessParams);
+    const queryParams = _.assign({}, this._excessParams);
 
     queryParams[opts.limitQueryParam] = this._limit;
     queryParams[opts.offsetQueryParam] = this._calculateOffset(page);
@@ -61,7 +60,7 @@ export class LimitOffsetQueryHandler {
   }
 
   setOptions(options) {
-    this._options = assign({}, defaultOptions, options);
+    this._options = _.assign({}, defaultOptions, options);
 
     return this;
   }
@@ -72,7 +71,7 @@ export class LimitOffsetQueryHandler {
       limit: null,
       offset: 0
     };
-    const result = assign({}, defaults);
+    const result = _.assign({}, defaults);
 
     if (queryParams.hasOwnProperty(limitQueryParam)) {
       result.limit = queryParams[limitQueryParam];
@@ -93,7 +92,7 @@ export class LimitOffsetQueryHandler {
       opts.offsetQueryParam
     ];
 
-    return omit(queryParams, paginationProperties);
+    return _.omit(queryParams, paginationProperties);
   }
 
   _calculateOffset(page) {

--- a/src/query-handlers/page-number-query-handler.js
+++ b/src/query-handlers/page-number-query-handler.js
@@ -1,5 +1,4 @@
-import assign from 'lodash.assign';
-import omit from 'lodash.omit';
+import _ from 'lodash';
 
 
 const defaultOptions = {
@@ -13,7 +12,7 @@ export class PageNumberQueryHandler {
   }
 
   makeParams(page) {
-    const queryParams = assign({}, this._excessParams);
+    const queryParams = _.assign({}, this._excessParams);
 
     queryParams[this._options.pageQueryParam] = page;
 
@@ -32,19 +31,19 @@ export class PageNumberQueryHandler {
   }
 
   setOptions(options) {
-    this._options = assign({}, defaultOptions, options);
+    this._options = _.assign({}, defaultOptions, options);
 
     return this;
   }
 
   _getExcess(queryParams) {
-    return omit(queryParams, [this._options.pageQueryParam]);
+    return _.omit(queryParams, [this._options.pageQueryParam]);
   }
 
   _parse(queryParams) {
     const {pageQueryParam} = this._options;
     const defaults = { page: 0 };
-    const result = assign({}, defaults);
+    const result = _.assign({}, defaults);
 
     if (queryParams.hasOwnProperty(pageQueryParam)) {
       result.page = queryParams[pageQueryParam];


### PR DESCRIPTION
As is, cherry-picking lodash tools is hurting the application
build size. Build tools are not able to recognize that `lodash.<util>` is
a member of `lodash`.

The end result is a duplicate bundling of lodash members.

Consolidating all clients on `lodash@4` should eliminate the duplication.