### PR TITLE
replace prepublish hook with prepare

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-prefix = "~"
+package-lock = false

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "cover": "rm -rf coverage && babel-node node_modules/.bin/isparta cover --root src/ --report text --report lcov --report html node_modules/.bin/_mocha -- src/test-setup.js $(find src -name '*-spec.js')",
     "coveralls": "cat coverage/lcov.info | coveralls",
     "jshint": "jshint src",
-    "prepublish": "npm run compile-cjs",
+    "prepare": "npm run compile-cjs",
     "test": "npm run cover && npm run jshint",
     "unit": "babel-node node_modules/.bin/_mocha --require src/test-setup.js --recursive src"
   },


### PR DESCRIPTION
In scope of: https://github.com/yola/ws-headless-builder/issues/41

In order to add compatibility with npm@4.x